### PR TITLE
店舗一覧、詳細ページ追加 #25

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,16 +25,16 @@ gem 'jbuilder', '~> 2.7'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+gem 'dotenv-rails'
 gem 'seed-fu'
-gem "dotenv-rails"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'factory_bot_rails'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem "rspec-rails"
-  gem "factory_bot_rails"
+  gem 'rspec-rails'
 end
 
 group :development do
@@ -45,13 +45,13 @@ group :development do
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'rails_best_practices'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'spring'
 end
 

--- a/app/assets/stylesheets/shops.scss
+++ b/app/assets/stylesheets/shops.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the shops controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/prefectures_controller.rb
+++ b/app/controllers/prefectures_controller.rb
@@ -1,7 +1,5 @@
 class PrefecturesController < ApplicationController
-  def index
-  end
+  def index; end
 
-  def show
-  end
+  def show; end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,0 +1,7 @@
+class ShopsController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,7 +1,9 @@
 class ShopsController < ApplicationController
   def index
+    @shops = Shop.all
   end
 
   def show
+    @shop = Shop.find(params[:id])
   end
 end

--- a/app/helpers/shops_helper.rb
+++ b/app/helpers/shops_helper.rb
@@ -1,0 +1,2 @@
+module ShopsHelper
+end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,22 +1,22 @@
-  # create_table "shops", force: :cascade do |t|
-  #   t.string "name"
-  #   t.string "tel_number"
-  #   t.string "address"
-  #   t.string "access"
-  #   t.string "open"
-  #   t.string "close"
-  #   t.integer "member_number"
-  #   t.string "member_since"
-  #   t.string "pizza_maker"
-  #   t.string "oven_used"
-  #   t.string "url"
-  #   t.float "latitude"
-  #   t.float "longitude"
-  #   t.datetime "created_at", precision: 6, null: false
-  #   t.datetime "updated_at", precision: 6, null: false
-  #   t.bigint "prefecture_id", null: false
-  #   t.index ["prefecture_id"], name: "index_shops_on_prefecture_id"
-  # end
+# create_table "shops", force: :cascade do |t|
+#   t.string "name"
+#   t.string "tel_number"
+#   t.string "address"
+#   t.string "access"
+#   t.string "open"
+#   t.string "close"
+#   t.integer "member_number"
+#   t.string "member_since"
+#   t.string "pizza_maker"
+#   t.string "oven_used"
+#   t.string "url"
+#   t.float "latitude"
+#   t.float "longitude"
+#   t.datetime "created_at", precision: 6, null: false
+#   t.datetime "updated_at", precision: 6, null: false
+#   t.bigint "prefecture_id", null: false
+#   t.index ["prefecture_id"], name: "index_shops_on_prefecture_id"
+# end
 
 class Shop < ApplicationRecord
   belongs_to :prefecture

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
   <nav class='navbar navbar-expand-lg navbar-light bg-light bg-dark'>
     <%= link_to "真のナポリピッツァ部", root_path, class: 'navbar-brand text-white' %>
-    <%= link_to "認定店一覧", '#', class: 'navbar-brand ml-auto text-white' %>
+    <%= link_to "認定店一覧", shops_path, class: 'navbar-brand ml-auto text-white' %>
 </header>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Shops#index</h1>
+<p>Find me in app/views/shops/index.html.erb</p>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,2 +1,21 @@
-<h1>Shops#index</h1>
-<p>Find me in app/views/shops/index.html.erb</p>
+<div class="my-4">
+  <h2 class="text-center">真のナポリピッツァ協会</h2>
+  <h2 class="text-center">認定店一覧</h2>
+</div>
+
+<table class="table table-striped table-dark table-hover">
+  <thead>
+    <tr>
+      <th scope="col">店舗名</th>
+      <th scope="col">住所</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @shops.each do |shop| %>
+    <tr>
+      <td scope="row"><%= link_to shop.name, shop_path(shop) %></td>
+      <td><%= shop.address %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,21 +1,23 @@
-<div class="my-4">
-  <h2 class="text-center">真のナポリピッツァ協会</h2>
-  <h2 class="text-center">認定店一覧</h2>
+<div class="container pt-3">
+  <div class="row">
+    <div class="col-md-10 offset-md-1">
+      <h2 class="float-left mb-5">認定店一覧</h2>
+        <table class="table table-striped table-dark table-hover">
+          <thead>
+            <tr>
+              <th scope="col">店舗名</th>
+              <th scope="col">住所</th>
+            </tr>
+          </thead>
+          <tbody>
+          <% @shops.each do |shop| %>
+            <tr>
+              <td scope="row"><%= link_to shop.name, shop_path(shop) %></td>
+              <td><%= shop.address %></td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+    </div>
+  </div>
 </div>
-
-<table class="table table-striped table-dark table-hover">
-  <thead>
-    <tr>
-      <th scope="col">店舗名</th>
-      <th scope="col">住所</th>
-    </tr>
-  </thead>
-  <tbody>
-  <% @shops.each do |shop| %>
-    <tr>
-      <td scope="row"><%= link_to shop.name, shop_path(shop) %></td>
-      <td><%= shop.address %></td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Shops#show</h1>
+<p>Find me in app/views/shops/show.html.erb</p>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,2 +1,55 @@
-<h1>Shops#show</h1>
-<p>Find me in app/views/shops/show.html.erb</p>
+<div class="container pt-3">
+  <div class="row">
+    <div class="col-md-10 offset-md-1">
+      <h2 class="float-left mb-5"><%= @shop.name %></h2>
+        <table class="table table-striped table-dark">
+          <tbody>
+            <tr>
+              <th scope="row">店舗名</th>
+              <td><%= @shop.name %></td>
+            </tr>
+            <tr>
+              <th>TEL</th>
+              <td><%= @shop.tel_number %></td>
+            </tr>
+            <tr>
+              <th>住所</th>
+              <td><%= @shop.address %></td>
+            </tr>
+            <tr>
+              <th>アクセス</th>
+              <td><%= @shop.access %></td>
+            </tr>
+            <tr>
+              <th>営業時間</th>
+              <td><%= simple_format(h(@shop.open), {}, sanitize: false, wrapper_tag: "div") %></td>
+            </tr>
+            <tr>
+              <th>定休日</th>
+              <td><%= @shop.close %></td>
+            </tr>
+            <tr>
+              <th>認定番号</th>
+              <td><%= @shop.member_number %></td>
+            </tr>
+            <tr>
+              <th>認定年月日</th>
+              <td><%= @shop.member_since %></td>
+            </tr>
+            <tr>
+              <th>ピッツァイオーロ</th>
+              <td><%= @shop.pizza_maker %></td>
+            </tr>
+            <tr>
+              <th>使用オーブン</th>
+              <td><%= @shop.oven_used %></td>
+            </tr>
+            <tr>
+              <th>ホームページ</th>
+              <td><%= link_to @shop.url,@shop.url %></td>
+            </tr>
+          </tbody>
+        </table>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   get 'shops/show'
   root "prefectures#index"
   resources :prefectures, only: %i[index show]
+  resources :shops, only: %i[index show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
-  get 'shops/index'
-  get 'shops/show'
-  root "prefectures#index"
+  root 'prefectures#index'
   resources :prefectures, only: %i[index show]
   resources :shops, only: %i[index show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'shops/index'
+  get 'shops/show'
   root "prefectures#index"
   resources :prefectures, only: %i[index show]
 end

--- a/spec/helpers/shops_helper_spec.rb
+++ b/spec/helpers/shops_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ShopsHelper. For example:
+#
+# describe ShopsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ShopsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/shops_spec.rb
+++ b/spec/requests/shops_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Shops", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/shops/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/shops/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/shops/index.html.erb_spec.rb
+++ b/spec/views/shops/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "shops/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/shops/show.html.erb_spec.rb
+++ b/spec/views/shops/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "shops/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
店舗一覧、店舗詳細ページを追加。
### 店舗一覧ページ
[![Image from Gyazo](https://i.gyazo.com/d1f0292f63c3379cd97ae4e75d1c7270.png)](https://gyazo.com/d1f0292f63c3379cd97ae4e75d1c7270)

### 店舗詳細ページ
[![Image from Gyazo](https://i.gyazo.com/177950d512e9640580a32d4086365c03.png)](https://gyazo.com/177950d512e9640580a32d4086365c03)

## 確認方法
ヘッダーの認定店一覧からのリンク、またはhttp://localhost:3000/shopsで一覧ページが表示されます。
一覧ページにて店舗名がリンクになっているので、それぞれ店舗詳細ページへ飛ぶことができます。

## コメント

細かい変更はrubocopによる自動整形となります。
各ページは現状仮デザインとなります。

close #25 