### PR TITLE
fix: link遷移時のturbolinksをオフにすることでエラー解決 #41

### DIFF
--- a/app/javascript/prefecture/index.js
+++ b/app/javascript/prefecture/index.js
@@ -1,21 +1,18 @@
-
 // Initialize and add the map
-// window.addEventListener('load', function () {
-//     initMap();
-// })
-window.onload = function () {
+
+window.addEventListener("load", () => {
   if (typeof gon !== 'undefined') {
     initMap();
-  }
-}
+  };
+});
 
 const marker = [];
 const infoWindow = [];
 
 function initMap() {
   const center_of_map = {
-    lat: gon.center_of_map_lat,
-    lng: gon.center_of_map_lng
+    lat: parseFloat(gon.center_of_map_lat),
+    lng: parseFloat(gon.center_of_map_lng)
   };
   const zoom_level_of_map = gon.zoom_level_of_map;
 
@@ -66,7 +63,7 @@ function initMap() {
       content: contentStr // 吹き出しに表示する内容をセット
     });
     markerEvent(i); // マーカーにクリックイベントを追加
-  }
+  };
 }
 
 // マーカーを消すためのcurrentInfoWindow

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <nav class='navbar navbar-expand-lg bg-dark top-logo nav-menu'>
-    <%= link_to "真のナポリピッツァ部", root_path, class: 'navbar-brand text-white' %>
-    <%= link_to "認定店一覧", shops_path, class: 'navbar-brand ml-auto text-white font-weight-light' %>
+    <%= link_to "真のナポリピッツァ部", root_path, class: 'navbar-brand text-white', 'data-turbolinks': false %>
+    <%= link_to "認定店一覧", shops_path, class: 'navbar-brand ml-auto text-white font-weight-light', 'data-turbolinks': false %>
   </nav>
 </header>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -13,7 +13,7 @@
             <tbody>
             <% @shops.each do |shop| %>
               <tr>
-                <td scope="row"><%= link_to shop.name, shop_path(shop) %></td>
+                <td scope="row"><%= link_to shop.name, shop_path(shop), 'data-turbolinks': false %></td>
                 <td><%= shop.address %></td>
               </tr>
             <% end %>


### PR DESCRIPTION
## 概要
ヘッダーのリンクを使って認定店一覧→トップページと遷移させるとグーグルマップが表示されないエラー解決しました！
（上記の遷移をさせるとdevツールのコンソールに"You have included the Google Maps JavaScript API multiple times on this page. This may cause unexpected errors."のエラー表示がある)

## 原因
"turbolinksを使用している場合、ページ遷移をしてもwindow以下のオブジェクトの状態が保たれる(メモリ上に残る)。
またwindow.onLoadイベントは、最初のページの表示時以外は呼ばれない。"
との理由で、エラーが表示されていた。と思われる。
なのでlink_toのオプションにdata-turbolinksを追加してturbolinksを無効化させることで解決。

## 確認方法

ヘッダーのリンクを使って店舗一覧→トップページのリンクを交互に押してもグーグルマップが表示されていること。

close #41 
