### PR TITLE
feat: トップに認定店一覧ボタンを追加 #51

### DIFF
--- a/app/assets/stylesheets/prefectures.scss
+++ b/app/assets/stylesheets/prefectures.scss
@@ -36,18 +36,32 @@ img.top-image {
      height: 160px;
     }
 }
-button {
+// button {
+//   position: absolute;
+//   top: 90%;
+//   left: 65%;
+
+//   @media screen and (max-width: 540px) {
+//       font-size: 0.7rem;
+//       position: absolute;
+//       top: 40%;
+//       left: 30%;
+//     }
+// }
+
+.top-button {
   position: absolute;
-  top: 90%;
+  top: 87%;
   left: 65%;
 
   @media screen and (max-width: 540px) {
-      font-size: 0.7rem;
-      position: absolute;
-      top: 40%;
-      left: 30%;
-    }
+    font-size: 0.7rem;
+    position: absolute;
+    top: 40%;
+    left: 30%;
+  }
 }
+
 
 /* Set the size of the div element that contains the map */
 #map {

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,11 +1,11 @@
 class ShopsController < ApplicationController
-   before_action :set_params_for_google_map, only: [:show]
+  before_action :set_params_for_google_map, only: [:show]
 
   def index
     @q = Shop.ransack(params[:q])
     @shops = @q.result(distinct: true)
   end
-
+ 
   def show
     @shop = Shop.find(params[:id])
   end

--- a/app/views/prefectures/index.html.erb
+++ b/app/views/prefectures/index.html.erb
@@ -5,7 +5,7 @@
         <h1 class='text-white font-weight-bold  mt-2'>真のナポリピッツァ協会認定店に</h1>
         <h1 class='text-white font-weight-bold mt-3 mb-5'>ナポリピッツァを食べに行こう</h1>
       </div>
-      <button class='btn btn-primary'>現在地から探す</button>
+      <%= link_to '認定店一覧を見る', shops_path, 'data-turbolinks': false, class: 'btn btn-dark top-button' %>
     </div>
   </div>
 </div>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -14,11 +14,15 @@
             </tr>
           </thead>
           <tbody>
-          <% @shops.each do |shop| %>
-            <tr>
-              <td scope="row"><%= link_to shop.name, shop_path(shop), 'data-turbolinks': false %></td>
-              <td><%= shop.address %></td>
-            </tr>
+          <% if @shops.present? %>
+            <% @shops.each do |shop| %>
+              <tr>
+                <td scope="row"><%= link_to shop.name, shop_path(shop), 'data-turbolinks': false %></td>
+                <td><%= shop.address %></td>
+              </tr>
+            <% end %>
+          <% else %>
+            <h3>検索した都道府県に認定店がありません</h3>
           <% end %>
           </tbody>
         </table>


### PR DESCRIPTION
## 概要

トップページのダミーボタンを削除し、認定店一覧ボタンを追加。
認定店の都道府県別検索をした時に、店舗がない県を検索した場合、検索した都道府県には認定店はありませんと表示させる。

## 確認方法

トップページに認定店一覧のリンクボタン押すと、shops_pathに飛ぶ。
都道府県別のセレクトボックスを選択して、認定店がない県を検索した場合にありませんと文言が表示されている。
(例:　青森県)

close #51 