### PR TITLE
fix:　店舗詳細ページに動的にtitleが表示されるよう設定 #93

### DIFF
--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,3 +1,4 @@
+<% set_meta_tags title: "#{@shop.name} - 真のナポリピッツァ部" %>
 <div class="container pt-3">
   <div class="row">
     <div class="col-12">


### PR DESCRIPTION
## 概要

店舗詳細ページで動的にメタタグ設定。
titleに各店舗名を表示させるようにした。

## 参考
https://creat4869.hatenablog.com/entry/2019/08/15/170109

close #93